### PR TITLE
Remove sudo from dependencies in _common.sh

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -5,7 +5,7 @@
 #=================================================
 
 # dependencies used by the app
-pkg_dependencies="ca-certificates curl sudo rsync"
+pkg_dependencies="ca-certificates curl rsync"
 
 NODEJS_VERSION=10
 


### PR DESCRIPTION
Should help keep level 8

## Problem

- *linter warning due to presence of sudo in dependencies (in scripts/_common.sh)*

## Solution

- *"sudo" removed from scripts_common.sh*

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
